### PR TITLE
Add email_type to MemberRequest struct.

### DIFF
--- a/members.go
+++ b/members.go
@@ -25,6 +25,7 @@ type ListOfMembers struct {
 
 type MemberRequest struct {
 	EmailAddress string                 `json:"email_address"`
+	EmailType    string                 `json:"email_type,omitempty"`
 	Status       string                 `json:"status"`
 	StatusIfNew  string                 `json:"status_if_new,omitempty"`
 	MergeFields  map[string]interface{} `json:"merge_fields,omitempty"`


### PR DESCRIPTION
Using your library for my Go client, we are using optional field `email_type` which is missing in MemberRequest struct.
API docs definition for email_type field: `Type of email this member asked to get (‘html’ or ‘text’).`

https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/#edit-put_lists_list_id_members_subscriber_hash